### PR TITLE
update 2023 cave week dates

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -63,7 +63,7 @@ export default function Hero() {
         Cave access is made possible by grassroots conservation efforts by <a href={CCH_DONATE_URL}target="_blank">Cave Conservancy of Hawai'i</a> and <a href={NSS_DONATE_URL} target="_blank">National Speleological Society</a>. We welcome donations.
       </p>
       <p className={styles.description}>
-        <a>Hawai'i Cave Week</a> is scheduled for January 31 - February 6, 2022. All are invited. Email us for more information.
+        <a>Hawai'i Cave Week</a> is scheduled for January 31 - February 5, 2023. All are invited. Email us for more information.
       </p>
       <p className={styles.description}>
       Want to get in touch? <a className={styles.email} onClick={handleClick}>hawaiigrotto@gmail.com</a>


### PR DESCRIPTION
Change 2023 Cave Week dates to January 30 through February 5, 2023 per Kim's request.
<img width="675" alt="CleanShot 2022-08-26 at 19 20 05@2x" src="https://user-images.githubusercontent.com/1177031/187016012-130f7701-d7d3-4039-b0ac-af5210ea7acb.png">

